### PR TITLE
[27.07.2025]: Integration testing hosted in containers

### DIFF
--- a/domitian-api/domitian-api/Program.cs
+++ b/domitian-api/domitian-api/Program.cs
@@ -30,6 +30,7 @@ builder.Services.AddCors(options =>
 });
 
 builder.Services.AddHttpContextAccessor();
+
 builder.Services
   .AddControllers(options =>
   {

--- a/domitian-api/domitian-api/appsettings.json
+++ b/domitian-api/domitian-api/appsettings.json
@@ -10,6 +10,11 @@
     "DomitianDefaultConnectionString": "Data Source=(localdb)\\MSSQLLocalDB;Initial Catalog=DomitianDb;Integrated Security=True;",
     "DomitianIntegrationTestingConnectionString": "Data Source=(localdb)\\MSSQLLocalDB;Initial Catalog=DomitianTestingDb; Integrated Security=true"
   },
+  "MsSqlServerTestContainer": {
+    "Database": "DomitianIntagrationTestsDb",
+    "HostName": "MsSqlServerTest",
+    "Password": ""
+  },
   "ApiUrls": {
     "ApiUrlBase": "https://localhost:7064"
   },

--- a/domitian-api/domitian.Business/Services/TokenService.cs
+++ b/domitian-api/domitian.Business/Services/TokenService.cs
@@ -54,15 +54,18 @@ namespace domitian.Business.Services
 
         public ClaimsPrincipal? GetPrincipalFromExpiredToken(string token)
         {
-            var validation = new TokenValidationParameters
+            var validationOptions = new TokenValidationParameters
             {
                 ValidIssuer = _jwtOptions.Value.Issuer,
                 ValidAudience = _jwtOptions.Value.Audience,
                 IssuerSigningKey = _key,
-                ValidateLifetime = false
+                ValidateLifetime = true,
+                ValidateIssuerSigningKey = true,
+                ValidateIssuer = true,
+                ValidateAudience = true,
             };
 
-            return new JwtSecurityTokenHandler().ValidateToken(token, validation, out _);
+            return new JwtSecurityTokenHandler().ValidateToken(token, validationOptions, out _);
         }
     }
 }

--- a/domitian-api/domitian.Tests.Integration/Helpers/SqlContainerTestConfig.cs
+++ b/domitian-api/domitian.Tests.Integration/Helpers/SqlContainerTestConfig.cs
@@ -1,0 +1,9 @@
+namespace domitian.Tests.Integration.Helpers
+{
+  public class SqlContainerTestConfig
+  {
+    public static string SectionName = "MsSqlServerTestContainer";
+
+    public string? Database { get; set; }
+  }
+}

--- a/domitian-api/domitian.Tests.Integration/TestServer.cs
+++ b/domitian-api/domitian.Tests.Integration/TestServer.cs
@@ -1,40 +1,63 @@
 using domitian.Tests.Integration.Helpers;
 using domitian_api.Data.Identity;
-using domitian_api.Infrastructure.Constants;
+using DotNet.Testcontainers.Containers;
 using Microsoft.AspNetCore.Mvc.Testing;
 using Microsoft.AspNetCore.TestHost;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.DependencyInjection.Extensions;
-
+using Testcontainers.MsSql;
 
 namespace domitian.Tests.Integration
 {
-  public class TestServer : WebApplicationFactory<Program>
+  public class TestServer : WebApplicationFactory<Program>, IAsyncLifetime
   {
+    private readonly IDatabaseContainer _msSqlContainer = new MsSqlBuilder()
+      .WithImage("mcr.microsoft.com/mssql/server:2019-CU27-ubuntu-20.04")
+      .Build();
+
     public TestServer() { }
+
+    public async Task InitializeAsync()
+    {
+      await _msSqlContainer.StartAsync();
+    }
 
     protected override void ConfigureWebHost(IWebHostBuilder builder)
     {
       IConfiguration? appConfig = null;
-      string? environment = null;
 
-      builder.ConfigureAppConfiguration((context, config) =>
-      {
-        var apiDir = typeof(Program).Assembly.Location;
-        appConfig = context.Configuration;
-        environment = context.HostingEnvironment.EnvironmentName;
-      });
+      builder.ConfigureAppConfiguration((context, config) => appConfig = context.Configuration);
 
       builder.ConfigureTestServices(services =>
       {
         services.RemoveAll(typeof(DbContextOptions<DomitianIDDbContext>));
+        //services.AddDbContext<DomitianIDDbContext>(options =>
+        //  options.UseSqlServer(
+        //    appConfig?.GetConnectionString(AppConstants.DomitianIntegrationTestsConnectionString),
+        //    options => options.MigrationsAssembly(AppConstants.dbContextAssembly)));
+
         services.AddDbContext<DomitianIDDbContext>(options =>
-          options.UseSqlServer(
-            appConfig?.GetConnectionString(AppConstants.DomitianIntegrationTestsConnectionString),
-            options => options.MigrationsAssembly(AppConstants.dbContextAssembly)));
+        {
+          var testContainerConfig = appConfig?
+          .GetRequiredSection(SqlContainerTestConfig.SectionName)
+          .Get<SqlContainerTestConfig>();
+
+          var connString = _msSqlContainer
+          .GetConnectionString()
+          .Replace("Database=master", $"Database={testContainerConfig?.Database}");
+
+          options.UseSqlServer(connString);
+        });
+
         services.AddScoped<TestDbSeeder>();
         services.AddSingleton<ApiUrlPathBuilder>();
       });
+    }
+
+    async Task IAsyncLifetime.DisposeAsync()
+    {
+      await _msSqlContainer.StopAsync();
+      await _msSqlContainer.DisposeAsync();
     }
   }
 }

--- a/domitian-api/domitian.Tests.Integration/domitian.Tests.Integration.csproj
+++ b/domitian-api/domitian.Tests.Integration/domitian.Tests.Integration.csproj
@@ -18,6 +18,8 @@
     <PackageReference Include="FluentAssertions" Version="7.2.0" />
     <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="8.0.16" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.14.1" />
+    <PackageReference Include="Testcontainers.MsSql" Version="4.6.0" />
+    <PackageReference Include="Testcontainers.Xunit" Version="4.6.0" />
     <PackageReference Include="xunit" Version="2.9.3" />
     <PackageReference Include="xunit.runner.visualstudio" Version="3.1.0">
       <PrivateAssets>all</PrivateAssets>


### PR DESCRIPTION
# Pull Request

## Context
Running the integration test's webhost in a container

## Description
Configure the webhost used in .net specific integration testing to run the different dependencies that the domitian api uses(in this issue's specific case being the MsSqlServer application) directly in-code.

## Changes in the codebase
Added the Testcontainers framework to the domitian integration tests' project(domitian.Tests.Integration). Added a built-in container from the Testcontainers lib. inside TestServer(the one that inherits from WebApplicationFactory<>) and configured the DbContext to use the connection string that is used to connect to the MsSqlServer inside the spun-up container. The TestServer class inherits from IAsyncLifetime to start and dispose of the container used for the integration tests' run.

## Changes outside of codebase
Install DockerDesktop on a windows host(my current local machine) or other equivalent app if using Linux-based systems so that the container that needs to be spun-up has the environment to deploy the container/s.

Fixes # (22)

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [X] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. 

- [X] Test 1:
1. Run DockerDesktop as admin
2. Add Breakpoints inside the tests for each of the api endpoints
3. Run the tests from the domitian.Tests.Integration project
4. Only a single container has to be deployed irrelevant of the endpoint and the controller it belongs to. Use DockerDesktop to keep track of the containers created and destroyed.
5. All tests have to pass

## Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [X] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes
- [X] Any dependent changes have been merged and published in downstream modules